### PR TITLE
feat: Sprint 1 P1 — 라운드 주기 설정, 온보딩, 사운드 이펙트

### DIFF
--- a/apps/web/src/app/(game)/page.tsx
+++ b/apps/web/src/app/(game)/page.tsx
@@ -1,15 +1,18 @@
 "use client";
 
 import { useEffect, useCallback, useState, useMemo } from "react";
-import { ArrowUp, ArrowDown, Trophy, Clock, Users, Flame, Star } from "lucide-react";
+import { ArrowUp, ArrowDown, Trophy, Clock, Users, Flame, Star, Settings, Volume2, VolumeX } from "lucide-react";
 import { useGameStore } from "@/stores/gameStore";
-import { getPrice, onPriceUpdate, computeStats } from "@/lib/game-engine";
+import { useSettingsStore, ROUND_DURATION_LABELS, type RoundDuration } from "@/stores/settingsStore";
+import { getPrice, onPriceUpdate, computeStats, setRoundDuration } from "@/lib/game-engine";
+import { playPickSound, playDrumroll, playWinSound, playLoseSound } from "@/lib/sound";
 import { formatPrice, formatChange } from "@/lib/format";
 import { useCountdown } from "@/hooks/useCountdown";
 import { AVATAR_LEVELS } from "@/types";
 import type { RoundResult } from "@/types";
 import MiniChart from "@/components/game/MiniChart";
 import ResultOverlay from "@/components/game/ResultOverlay";
+import Onboarding from "@/components/game/Onboarding";
 import ChimpCharacter from "@/components/character/ChimpCharacter";
 
 const MAX_CHART_TICKS = 20;
@@ -39,10 +42,26 @@ export default function GamePage() {
     claimMissionReward,
   } = useGameStore();
 
+  const {
+    roundDuration,
+    soundEnabled,
+    hasSeenOnboarding,
+    setRoundDuration: setDuration,
+    toggleSound,
+    markOnboardingSeen,
+  } = useSettingsStore();
+
+  const [showSettings, setShowSettings] = useState(false);
+
   // Ensure daily missions exist
   useEffect(() => {
     ensureDailyMissions();
   }, [ensureDailyMissions]);
+
+  // Sync round duration setting with engine
+  useEffect(() => {
+    setRoundDuration(roundDuration);
+  }, [roundDuration]);
 
   const stats = useMemo(() => computeStats(roundHistory), [roundHistory]);
 
@@ -86,24 +105,35 @@ export default function GamePage() {
     return unsub;
   }, [roundId, roundSymbol]);
 
-  // Auto-resolve when round resolves
+  // Play drumroll when round closes
   const roundPhase = currentRound?.phase;
 
   useEffect(() => {
+    if (roundPhase === "CLOSED" && myPick && soundEnabled) {
+      playDrumroll();
+    }
+  }, [roundPhase, myPick, soundEnabled]);
+
+  // Auto-resolve when round resolves
+  useEffect(() => {
     if (roundPhase !== "RESOLVED" || !myPick) return;
 
-    // Use microtask to avoid synchronous setState in effect
     queueMicrotask(() => {
       const result = resolveMyPick();
       if (result) {
         setResolvedResult(result);
+        if (soundEnabled) {
+          if (result.isCorrect) playWinSound();
+          else playLoseSound();
+        }
       }
     });
-  }, [roundPhase, myPick, resolveMyPick]);
+  }, [roundPhase, myPick, resolveMyPick, soundEnabled]);
 
   const handlePick = useCallback((direction: "UP" | "DOWN") => {
     pickDirection(direction);
-  }, [pickDirection]);
+    if (soundEnabled) playPickSound();
+  }, [pickDirection, soundEnabled]);
 
   const handleResultDismiss = useCallback(() => {
     setResolvedResult(null);
@@ -143,14 +173,66 @@ export default function GamePage() {
               </span>
             </div>
           </div>
-          <div className="flex items-center gap-1.5 bg-banana/15 px-3 py-1.5 rounded-2xl border-2 border-banana/30">
-            <Trophy size={14} className="text-banana" />
-            <span className="font-mono font-bold text-banana tabular-nums text-sm">
-              {totalScore.toLocaleString()}
-            </span>
-            <span className="text-xs text-banana/70">점</span>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-1.5 bg-banana/15 px-3 py-1.5 rounded-2xl border-2 border-banana/30">
+              <Trophy size={14} className="text-banana" />
+              <span className="font-mono font-bold text-banana tabular-nums text-sm">
+                {totalScore.toLocaleString()}
+              </span>
+              <span className="text-xs text-banana/70">점</span>
+            </div>
+            <button
+              onClick={() => setShowSettings(!showSettings)}
+              className="p-2 rounded-2xl border-2 border-card-border bg-white text-text-secondary hover:text-banana transition-colors"
+              aria-label="설정"
+            >
+              <Settings size={16} />
+            </button>
           </div>
         </div>
+
+        {/* Settings panel */}
+        {showSettings && (
+          <div className="bg-white rounded-3xl p-4 border-2 border-card-border clay">
+            <p className="text-sm font-semibold text-text-primary font-sans mb-3">설정</p>
+            <div className="space-y-3">
+              <div>
+                <p className="text-xs text-text-secondary font-sans mb-1.5">라운드 시간</p>
+                <div className="flex gap-2">
+                  {([30, 60, 300] as RoundDuration[]).map((d) => (
+                    <button
+                      key={d}
+                      onClick={() => setDuration(d)}
+                      className={[
+                        "flex-1 py-2 rounded-2xl text-xs font-bold font-sans border-2 transition-all btn-clay",
+                        roundDuration === d
+                          ? "border-banana text-banana bg-banana/12 clay-sm"
+                          : "border-card-border text-text-secondary bg-white hover:border-banana/40",
+                      ].join(" ")}
+                    >
+                      {ROUND_DURATION_LABELS[d]}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-xs text-text-secondary font-sans">사운드</span>
+                <button
+                  onClick={toggleSound}
+                  className={[
+                    "flex items-center gap-1 px-3 py-1.5 rounded-2xl text-xs font-bold border-2 transition-all",
+                    soundEnabled
+                      ? "border-up/30 text-up bg-up/8"
+                      : "border-card-border text-text-secondary bg-white",
+                  ].join(" ")}
+                >
+                  {soundEnabled ? <Volume2 size={12} /> : <VolumeX size={12} />}
+                  {soundEnabled ? "ON" : "OFF"}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
 
         {/* Round Status Card */}
         {currentRound && (
@@ -480,6 +562,11 @@ export default function GamePage() {
           result={resolvedResult}
           onDismiss={handleResultDismiss}
         />
+      )}
+
+      {/* Onboarding */}
+      {!hasSeenOnboarding && (
+        <Onboarding onComplete={markOnboardingSeen} />
       )}
     </>
   );

--- a/apps/web/src/components/game/Onboarding.tsx
+++ b/apps/web/src/components/game/Onboarding.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useState } from "react";
+import ChimpCharacter from "@/components/character/ChimpCharacter";
+import Button from "@/components/ui/Button";
+
+interface OnboardingProps {
+  onComplete: () => void;
+}
+
+const STEPS = [
+  {
+    mood: "idle" as const,
+    title: "침팬지픽에 오신 걸 환영해요!",
+    description: "주식과 코인 가격이 오를지 내릴지 예측하는 게임이에요.",
+    emoji: "🦍",
+  },
+  {
+    mood: "up" as const,
+    title: "30초마다 새 라운드!",
+    description: "시스템이 랜덤 종목을 출제해요. UP 또는 DOWN을 선택하세요!",
+    emoji: "⏱️",
+  },
+  {
+    mood: "win" as const,
+    title: "소수파가 이기면 대박!",
+    description: "적은 쪽을 맞추면 최대 5배 점수! 역발상이 승리의 열쇠에요.",
+    emoji: "🏆",
+  },
+];
+
+export default function Onboarding({ onComplete }: OnboardingProps) {
+  const [step, setStep] = useState(0);
+  const current = STEPS[step];
+  const isLast = step === STEPS.length - 1;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
+      <div className="mx-4 w-full max-w-sm rounded-3xl bg-white p-8 text-center border-4 border-banana clay animate-pop-in">
+        <div className="mb-2 text-4xl">{current.emoji}</div>
+
+        <ChimpCharacter mood={current.mood} size={80} className="mx-auto mb-4" />
+
+        <h2 className="text-xl font-heading font-bold text-text-primary mb-2">
+          {current.title}
+        </h2>
+
+        <p className="text-sm text-text-secondary font-sans mb-6">
+          {current.description}
+        </p>
+
+        {/* Step indicators */}
+        <div className="flex justify-center gap-2 mb-5">
+          {STEPS.map((_, i) => (
+            <div
+              key={i}
+              className={[
+                "w-2 h-2 rounded-full transition-all",
+                i === step ? "bg-banana w-6" : "bg-card-border",
+              ].join(" ")}
+            />
+          ))}
+        </div>
+
+        <div className="flex gap-2">
+          {step > 0 && (
+            <Button
+              variant="outline"
+              size="md"
+              className="flex-1"
+              onClick={() => setStep(step - 1)}
+            >
+              이전
+            </Button>
+          )}
+          <Button
+            variant="primary"
+            size="md"
+            className="flex-1 btn-clay"
+            onClick={() => {
+              if (isLast) onComplete();
+              else setStep(step + 1);
+            }}
+          >
+            {isLast ? "시작하기! 🍌" : "다음"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/game-engine/index.ts
+++ b/apps/web/src/lib/game-engine/index.ts
@@ -12,6 +12,7 @@ export {
   startRoundEngine,
   onRoundUpdate,
   getCurrentRound,
+  setRoundDuration,
 } from "./round-engine";
 
 export { calculateScore, computeStats } from "./score-engine";

--- a/apps/web/src/lib/game-engine/round-engine.ts
+++ b/apps/web/src/lib/game-engine/round-engine.ts
@@ -5,7 +5,6 @@
 
 import {
   SYMBOLS,
-  ROUND_OPEN_MS,
   ROUND_RESOLVE_DELAY_MS,
   ROUND_BREAK_MS,
   type Round,
@@ -17,6 +16,7 @@ import { getPrice } from "./price-engine";
 let currentRound: Round | null = null;
 let roundTimer: ReturnType<typeof setTimeout> | null = null;
 const listeners: Set<(round: Round) => void> = new Set();
+let configuredOpenMs = 30_000;
 
 function generateId(): string {
   return crypto.randomUUID();
@@ -63,8 +63,8 @@ function startNewRound() {
     result: null,
     phase: "OPEN",
     opensAt: new Date(now).toISOString(),
-    closesAt: new Date(now + ROUND_OPEN_MS).toISOString(),
-    resolvesAt: new Date(now + ROUND_OPEN_MS + ROUND_RESOLVE_DELAY_MS).toISOString(),
+    closesAt: new Date(now + configuredOpenMs).toISOString(),
+    resolvesAt: new Date(now + configuredOpenMs + ROUND_RESOLVE_DELAY_MS).toISOString(),
     upRatio: generateNpcRatio(),
   };
 
@@ -73,7 +73,7 @@ function startNewRound() {
   // Schedule close
   roundTimer = setTimeout(() => {
     closeRound();
-  }, ROUND_OPEN_MS);
+  }, configuredOpenMs);
 }
 
 /** Close predictions and resolve */
@@ -114,8 +114,14 @@ function resolveRound() {
   }, ROUND_BREAK_MS);
 }
 
+/** Set round duration in seconds */
+export function setRoundDuration(seconds: number) {
+  configuredOpenMs = seconds * 1000;
+}
+
 /** Start the round engine loop */
-export function startRoundEngine(): () => void {
+export function startRoundEngine(durationSeconds?: number): () => void {
+  if (durationSeconds) configuredOpenMs = durationSeconds * 1000;
   if (currentRound) {
     return () => {
       if (roundTimer) {

--- a/apps/web/src/lib/sound.ts
+++ b/apps/web/src/lib/sound.ts
@@ -1,0 +1,64 @@
+/**
+ * Simple sound effects using Web Audio API
+ */
+
+let audioCtx: AudioContext | null = null;
+
+function getCtx(): AudioContext {
+  if (!audioCtx) audioCtx = new AudioContext();
+  return audioCtx;
+}
+
+function playTone(freq: number, duration: number, type: OscillatorType = "sine", volume = 0.15) {
+  try {
+    const ctx = getCtx();
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.type = type;
+    osc.frequency.value = freq;
+    gain.gain.value = volume;
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + duration);
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.start();
+    osc.stop(ctx.currentTime + duration);
+  } catch {
+    // Audio not available
+  }
+}
+
+export function playPickSound() {
+  playTone(600, 0.1, "sine", 0.12);
+  setTimeout(() => playTone(800, 0.08, "sine", 0.1), 50);
+}
+
+export function playWinSound() {
+  playTone(523, 0.15, "sine", 0.15);
+  setTimeout(() => playTone(659, 0.15, "sine", 0.15), 100);
+  setTimeout(() => playTone(784, 0.2, "sine", 0.15), 200);
+  setTimeout(() => playTone(1047, 0.3, "triangle", 0.12), 300);
+}
+
+export function playLoseSound() {
+  playTone(400, 0.2, "sawtooth", 0.08);
+  setTimeout(() => playTone(300, 0.3, "sawtooth", 0.06), 150);
+}
+
+export function playDrumroll() {
+  for (let i = 0; i < 12; i++) {
+    setTimeout(() => playTone(200 + Math.random() * 100, 0.08, "triangle", 0.06), i * 80);
+  }
+}
+
+export function playLevelUp() {
+  playTone(523, 0.12, "sine", 0.15);
+  setTimeout(() => playTone(659, 0.12, "sine", 0.15), 80);
+  setTimeout(() => playTone(784, 0.12, "sine", 0.15), 160);
+  setTimeout(() => playTone(1047, 0.12, "sine", 0.15), 240);
+  setTimeout(() => playTone(1318, 0.3, "triangle", 0.12), 320);
+}
+
+export function playMissionComplete() {
+  playTone(880, 0.1, "sine", 0.12);
+  setTimeout(() => playTone(1100, 0.15, "triangle", 0.1), 80);
+}

--- a/apps/web/src/stores/settingsStore.ts
+++ b/apps/web/src/stores/settingsStore.ts
@@ -1,0 +1,39 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type RoundDuration = 30 | 60 | 300;
+
+interface SettingsState {
+  roundDuration: RoundDuration;
+  soundEnabled: boolean;
+  hasSeenOnboarding: boolean;
+
+  setRoundDuration: (duration: RoundDuration) => void;
+  toggleSound: () => void;
+  markOnboardingSeen: () => void;
+}
+
+export const ROUND_DURATION_LABELS: Record<RoundDuration, string> = {
+  30: "30초",
+  60: "1분",
+  300: "5분",
+};
+
+export const useSettingsStore = create<SettingsState>()(
+  persist(
+    (set) => ({
+      roundDuration: 30,
+      soundEnabled: true,
+      hasSeenOnboarding: false,
+
+      setRoundDuration: (duration) => set({ roundDuration: duration }),
+      toggleSound: () => set((s) => ({ soundEnabled: !s.soundEnabled })),
+      markOnboardingSeen: () => set({ hasSeenOnboarding: true }),
+    }),
+    {
+      name: "chimp-pick-settings",
+    }
+  )
+);


### PR DESCRIPTION
### **User description**
## Summary

- **라운드 주기 설정**: 30초/1분/5분 선택 가능. 설정 패널 토글.
- **온보딩 튜토리얼**: 첫 방문 시 3단계 가이드 (게임 소개 → 라운드 설명 → 소수파 보너스)
- **사운드 이펙트**: Web Audio API 기반 (선택/드럼롤/승리/패배/레벨업/미션완료)
- **음소거 토글**: 설정 패널에서 ON/OFF

## Test plan

- [ ] 설정 패널 열기 → 라운드 시간 변경 → 다음 라운드부터 적용 확인
- [ ] localStorage 초기화 후 접속 → 온보딩 3단계 표시 확인
- [ ] UP/DOWN 선택 시 효과음 확인
- [ ] 결과 발표 시 드럼롤 → 승리/패배 사운드 확인
- [ ] 음소거 토글 → 사운드 OFF 확인
- [ ] ESLint + TypeScript 빌드 통과

Closes #5

---
🤖 Generated by Claude Code [claude-sonnet-4-6]


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce configurable round durations (30s, 1m, 5m).

- Add a multi-step onboarding tutorial for new users.

- Implement sound effects for game actions and events.

- Provide a toggle for sound effects in settings.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  GamePage["apps/web/src/app/(game)/page.tsx"]
  SettingsStore["apps/web/src/stores/settingsStore.ts"]
  OnboardingComponent["apps/web/src/components/game/Onboarding.tsx"]
  SoundLib["apps/web/src/lib/sound.ts"]
  RoundEngine["apps/web/src/lib/game-engine/round-engine.ts"]

  GamePage -- "uses/updates" --> SettingsStore
  GamePage -- "renders" --> OnboardingComponent
  GamePage -- "calls" --> SoundLib
  GamePage -- "configures" --> RoundEngine
  SettingsStore -- "updates" --> RoundEngine
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Integrate settings, onboarding, and sound effects into game page</code></dd></summary>
<hr>

apps/web/src/app/(game)/page.tsx

<ul><li>Integrated <code>useSettingsStore</code> for round duration, sound, and onboarding <br>states.<br> <li> Added a settings panel with options to change round duration and <br>toggle sound.<br> <li> Implemented sound effect triggers for game actions like picking, <br>winning, and losing.<br> <li> Rendered the new <code>Onboarding</code> component for first-time users.</ul>


</details>


  </td>
  <td><a href="https://github.com/gguloadoong/chimp-pick/pull/6/files#diff-dd20b1a896669dda269ca0a70ed87f5d53e594f7a9449867b156c8d5dbd062b2">+99/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Feature</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Onboarding.tsx</strong><dd><code>Add multi-step onboarding tutorial component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/components/game/Onboarding.tsx

<ul><li>Created a new component for a multi-step onboarding tutorial.<br> <li> Displays game introduction, round explanation, and minority bonus <br>details.<br> <li> Manages steps with navigation buttons and calls <code>onComplete</code> when <br>finished.</ul>


</details>


  </td>
  <td><a href="https://github.com/gguloadoong/chimp-pick/pull/6/files#diff-221e8b5319d4e298bc322391053c7cce0466ed301734be981f9fff7589c94cb9">+91/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Export</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export round duration setter from game engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/lib/game-engine/index.ts

- Exported the new `setRoundDuration` function from `round-engine`.


</details>


  </td>
  <td><a href="https://github.com/gguloadoong/chimp-pick/pull/6/files#diff-de6da5928f0aa6b07b7e9a665355f92c6eb5481296b559c9c988d0628dc17db4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>round-engine.ts</strong><dd><code>Make round duration configurable in game engine</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/lib/game-engine/round-engine.ts

<ul><li>Replaced hardcoded round duration with a configurable <code>configuredOpenMs</code> <br>variable.<br> <li> Added <code>setRoundDuration</code> function to dynamically update the round <br>length.<br> <li> Modified <code>startRoundEngine</code> to accept an initial duration.</ul>


</details>


  </td>
  <td><a href="https://github.com/gguloadoong/chimp-pick/pull/6/files#diff-c5e1f0b959b4e33554aad9e1a6101eb4024fa97e85518c215668ed4a2c96c34c">+11/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Audio</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sound.ts</strong><dd><code>Add Web Audio API-based sound effects utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/lib/sound.ts

<ul><li>Implemented a new utility for playing various sound effects using Web <br>Audio API.<br> <li> Provides functions for pick, win, lose, drumroll, level up, and <br>mission complete sounds.<br> <li> Includes basic error handling for audio context creation.</ul>


</details>


  </td>
  <td><a href="https://github.com/gguloadoong/chimp-pick/pull/6/files#diff-8c5123fb223b5f757fd8564e6c2142846728465d13b137cf52dd86d3c8b1889a">+64/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>State management</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settingsStore.ts</strong><dd><code>Introduce persistent settings store for user preferences</code>&nbsp; </dd></summary>
<hr>

apps/web/src/stores/settingsStore.ts

<ul><li>Created a new Zustand store for managing user settings, persisted to <br><code>localStorage</code>.<br> <li> Stores <code>roundDuration</code>, <code>soundEnabled</code>, and <code>hasSeenOnboarding</code> states.<br> <li> Provides actions to update these settings, including a sound toggle.</ul>


</details>


  </td>
  <td><a href="https://github.com/gguloadoong/chimp-pick/pull/6/files#diff-e2b9ab9fe6997dcfc6021a533fc250f62db75202e68f2f87fde39ea992ff30d8">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **설정 패널 추가** – 라운드 시간(30/60/300초) 선택 및 사운드 ON/OFF 토글 기능 추가
* **온보딩 화면 추가** – 첫 사용 시 게임 사용법을 안내하는 3단계 튜토리얼 화면 추가
* **사운드 효과 추가** – 선택, 승리/패배, 라운드 클로징 등 게임 액션에 따른 음향 효과 추가
* **설정 자동 저장** – 선택한 설정이 자동으로 저장되어 다음 접속 시 유지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->