### PR TITLE
feat: v2 — 시즌 시스템, 스피드 라운드

### DIFF
--- a/apps/web/src/app/(game)/page.tsx
+++ b/apps/web/src/app/(game)/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useCallback, useState, useMemo } from "react";
 import { ArrowUp, ArrowDown, Trophy, Clock, Users, Flame, Star, Settings, Volume2, VolumeX } from "lucide-react";
 import { useGameStore } from "@/stores/gameStore";
 import { useSettingsStore, ROUND_DURATION_LABELS, type RoundDuration, type ThemeMode } from "@/stores/settingsStore";
-import { getPrice, onPriceUpdate, computeStats, setRoundDuration } from "@/lib/game-engine";
+import { getPrice, onPriceUpdate, computeStats, setRoundDuration, getCurrentSeason, getSeasonTimeRemaining } from "@/lib/game-engine";
 import { playPickSound, playDrumroll, playWinSound, playLoseSound } from "@/lib/sound";
 import { formatPrice, formatChange } from "@/lib/format";
 import { useCountdown } from "@/hooks/useCountdown";
@@ -282,7 +282,7 @@ export default function GamePage() {
                   currentRound.phase === "RESOLVED" ? "bg-down" : "bg-text-secondary",
                 ].join(" ")} />
                 <span className="text-xs font-semibold font-sans text-text-secondary">
-                  {currentRound.phase === "OPEN" && "예측 진행 중"}
+                  {currentRound.phase === "OPEN" && (currentRound.isSpeedRound ? "⚡ 스피드 라운드!" : "예측 진행 중")}
                   {currentRound.phase === "CLOSED" && "결과 계산 중..."}
                   {currentRound.phase === "RESOLVED" && "결과 발표!"}
                   {currentRound.phase === "WAITING" && "다음 라운드 준비 중"}
@@ -584,9 +584,16 @@ export default function GamePage() {
           </div>
         )}
 
+        {/* Season info */}
+        <div className="bg-white rounded-2xl p-3 border border-card-border clay-sm text-center">
+          <p className="text-xs text-text-secondary font-sans">
+            🏆 {getCurrentSeason().label} 시즌 · 남은 시간 {getSeasonTimeRemaining().days}일 {getSeasonTimeRemaining().hours}시간
+          </p>
+        </div>
+
         {/* Footer info */}
         <p className="text-center text-xs text-text-secondary font-sans">
-          30초마다 새 라운드 · 소수파 보너스 최대 5배 · 적게 고른 쪽이 이기면 대박!
+          소수파 보너스 최대 5배 · ⚡ 스피드 라운드 1.5배!
         </p>
       </div>
 

--- a/apps/web/src/lib/game-engine/index.ts
+++ b/apps/web/src/lib/game-engine/index.ts
@@ -25,6 +25,9 @@ export type { Question, QuestionResult } from "./question-provider";
 export { computeTitleStats, getEarnedTitles, getAllTitles } from "./title-engine";
 export type { Title } from "./title-engine";
 
+export { getCurrentSeason, getSeasonTimeRemaining, getSeasonBadge, getSeasonBonus } from "./season-engine";
+export type { Season, SeasonRecord } from "./season-engine";
+
 export {
   generateDailyMissions,
   needsReset,

--- a/apps/web/src/lib/game-engine/round-engine.ts
+++ b/apps/web/src/lib/game-engine/round-engine.ts
@@ -42,9 +42,14 @@ function transitionTo(phase: RoundPhase) {
 }
 
 /** Start a new round */
+const SPEED_ROUND_CHANCE = 0.1;
+const SPEED_ROUND_MS = 10_000;
+
 function startNewRound() {
   const question = generateQuestion();
   const now = Date.now();
+  const isSpeed = Math.random() < SPEED_ROUND_CHANCE;
+  const roundMs = isSpeed ? SPEED_ROUND_MS : configuredOpenMs;
 
   const entryPrice = question.symbol
     ? getPrice(question.symbol).price
@@ -60,16 +65,17 @@ function startNewRound() {
     result: null,
     phase: "OPEN",
     opensAt: new Date(now).toISOString(),
-    closesAt: new Date(now + configuredOpenMs).toISOString(),
-    resolvesAt: new Date(now + configuredOpenMs + ROUND_RESOLVE_DELAY_MS).toISOString(),
+    closesAt: new Date(now + roundMs).toISOString(),
+    resolvesAt: new Date(now + roundMs + ROUND_RESOLVE_DELAY_MS).toISOString(),
     upRatio: generateNpcRatio(),
     questionCategory: question.category,
     questionEmoji: question.categoryEmoji,
     questionLabel: question.categoryLabel,
-    questionTitle: question.title,
-    questionDesc: question.description,
+    questionTitle: isSpeed ? `⚡ ${question.title}` : question.title,
+    questionDesc: isSpeed ? "스피드 라운드! 10초 안에 선택하세요!" : question.description,
     optionA: question.optionA,
     optionB: question.optionB,
+    isSpeedRound: isSpeed,
   };
 
   notify(currentRound);
@@ -77,7 +83,7 @@ function startNewRound() {
   // Schedule close
   roundTimer = setTimeout(() => {
     closeRound();
-  }, configuredOpenMs);
+  }, roundMs);
 }
 
 /** Close predictions and resolve */

--- a/apps/web/src/lib/game-engine/season-engine.ts
+++ b/apps/web/src/lib/game-engine/season-engine.ts
@@ -1,0 +1,81 @@
+/**
+ * Season Engine — weekly seasons with rankings and rewards
+ * Season: Monday 00:00 → Sunday 23:59
+ */
+
+export interface Season {
+  id: string;
+  startDate: string;
+  endDate: string;
+  label: string;
+}
+
+export interface SeasonRecord {
+  seasonId: string;
+  label: string;
+  score: number;
+  rank: number;
+  rounds: number;
+  badge: string | null;
+}
+
+function getMonday(date: Date): Date {
+  const d = new Date(date);
+  const day = d.getDay();
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1);
+  d.setDate(diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function getSunday(monday: Date): Date {
+  const d = new Date(monday);
+  d.setDate(d.getDate() + 6);
+  d.setHours(23, 59, 59, 999);
+  return d;
+}
+
+export function getCurrentSeason(): Season {
+  const now = new Date();
+  const monday = getMonday(now);
+  const sunday = getSunday(monday);
+
+  const weekNum = Math.ceil(
+    (monday.getTime() - new Date(monday.getFullYear(), 0, 1).getTime()) / (7 * 86400_000)
+  );
+
+  return {
+    id: `${monday.getFullYear()}-W${String(weekNum).padStart(2, "0")}`,
+    startDate: monday.toISOString(),
+    endDate: sunday.toISOString(),
+    label: `${monday.getMonth() + 1}월 ${weekNum}주차`,
+  };
+}
+
+export function getSeasonTimeRemaining(): { days: number; hours: number } {
+  const season = getCurrentSeason();
+  const end = new Date(season.endDate).getTime();
+  const now = Date.now();
+  const diff = Math.max(0, end - now);
+
+  return {
+    days: Math.floor(diff / 86400_000),
+    hours: Math.floor((diff % 86400_000) / 3600_000),
+  };
+}
+
+export function getSeasonBadge(rank: number): string | null {
+  if (rank === 1) return "🥇";
+  if (rank === 2) return "🥈";
+  if (rank === 3) return "🥉";
+  return null;
+}
+
+export function getSeasonBonus(rank: number): number {
+  if (rank === 1) return 500;
+  if (rank === 2) return 300;
+  if (rank === 3) return 200;
+  if (rank <= 5) return 100;
+  if (rank <= 10) return 50;
+  return 0;
+}

--- a/apps/web/src/stores/gameStore.ts
+++ b/apps/web/src/stores/gameStore.ts
@@ -76,11 +76,12 @@ export const useGameStore = create<GameState>()(
         if (roundHistory.some((r) => r.roundId === currentRound.id)) return null;
 
         const isCorrect = myPick.direction === currentRound.result;
-        const score = calculateScore(
+        const baseScore = calculateScore(
           myPick.direction,
           currentRound.result,
           currentRound.upRatio,
         );
+        const score = currentRound.isSpeedRound ? Math.round(baseScore * 1.5) : baseScore;
 
         const result: RoundResult = {
           roundId: currentRound.id,

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -35,6 +35,8 @@ export interface Round {
   questionDesc: string;
   optionA: string;
   optionB: string;
+  /** Speed round: shorter duration, bonus multiplier */
+  isSpeedRound: boolean;
 }
 
 export interface RoundPick {


### PR DESCRIPTION
## Summary

- **시즌 시스템**: 주간 시즌 (월~일), 남은 시간 표시, 순위별 보너스 (1위 500점)
- **스피드 라운드**: 10초 초고속 라운드 (10% 확률), 점수 1.5배 보너스
- **시즌 배지**: Top 3 메달 🥇🥈🥉

## Test plan

- [ ] 게임 화면에 시즌 정보 + 남은 시간 표시 확인
- [ ] 여러 라운드 중 스피드 라운드 발생 확인 (⚡ 표시)
- [ ] 스피드 라운드 적중 시 1.5배 점수 확인
- [ ] ESLint + TypeScript 빌드 통과

Closes #19

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능
* **스피드 라운드**: 단축된 10초 라운드에서 점수 1.5배 보너스 제공
* **시즌 시스템**: 주간 시즌 순위, 배지, 랭크별 보너스(최대 5배) 추가

## 개선 사항
* 게임 화면에 현재 시즌 정보 및 남은 시간(일/시간) 표시
* 스피드 라운드 진행 중 상태 안내 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->