### PR TITLE
feat: v2.3 — 챌린지 모드, 라운드 카운터

### DIFF
--- a/apps/web/src/app/(game)/page.tsx
+++ b/apps/web/src/app/(game)/page.tsx
@@ -42,6 +42,9 @@ export default function GamePage() {
     resolveMyPick,
     ensureDailyMissions,
     claimMissionReward,
+    challenge,
+    startChallenge,
+    getTodayRounds,
   } = useGameStore();
 
   const {
@@ -196,7 +199,10 @@ export default function GamePage() {
               </span>
             </div>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-text-secondary font-sans bg-bg-primary px-2 py-1 rounded-xl border border-card-border">
+              오늘 {getTodayRounds()}R
+            </span>
             <div className="flex items-center gap-1.5 bg-banana/15 px-3 py-1.5 rounded-2xl border-2 border-banana/30">
               <Trophy size={14} className="text-banana" />
               <span className="font-mono font-bold text-banana tabular-nums text-sm">
@@ -293,6 +299,23 @@ export default function GamePage() {
               </div>
             </div>
           </div>
+        )}
+
+        {/* Challenge */}
+        {challenge?.active ? (
+          <div className="bg-banana/10 rounded-2xl p-3 border-2 border-banana/30 text-center">
+            <p className="font-heading font-bold text-banana text-sm">
+              🎯 챌린지 진행 중! {challenge.wins}/{5 - challenge.roundsLeft + challenge.wins} 적중 · 남은 {challenge.roundsLeft}라운드
+            </p>
+            <p className="text-xs text-banana/70 font-sans mt-1">5연속 적중 시 점수 3배!</p>
+          </div>
+        ) : (
+          <button
+            onClick={startChallenge}
+            className="w-full py-2.5 rounded-2xl border-2 border-banana/30 bg-banana/5 text-banana text-sm font-bold font-sans transition-all hover:bg-banana/15 btn-clay"
+          >
+            🎯 챌린지 시작 (5라운드 연속 적중 → 3배!)
+          </button>
         )}
 
         {/* Round Status Card */}

--- a/apps/web/src/stores/gameStore.ts
+++ b/apps/web/src/stores/gameStore.ts
@@ -24,6 +24,7 @@ interface GameState {
   dailyMissions: DailyMissionState | null;
   attendance: { lastDate: string; streak: number; totalDays: number };
   selectedTitle: string | null;
+  challenge: { active: boolean; roundsLeft: number; wins: number } | null;
 
   // Actions
   setRound: (round: Round) => void;
@@ -34,6 +35,8 @@ interface GameState {
   claimMissionReward: (missionId: string) => number;
   checkAttendance: () => { isNew: boolean; streak: number; bonus: number };
   setSelectedTitle: (titleId: string | null) => void;
+  startChallenge: () => void;
+  getTodayRounds: () => number;
 }
 
 export const useGameStore = create<GameState>()(
@@ -46,6 +49,7 @@ export const useGameStore = create<GameState>()(
       dailyMissions: null,
       attendance: { lastDate: "", streak: 0, totalDays: 0 },
       selectedTitle: null,
+      challenge: null,
 
       setRound: (round) => {
         const prev = get().currentRound;
@@ -117,10 +121,28 @@ export const useGameStore = create<GameState>()(
           );
         }
 
+        // Update challenge
+        let { challenge } = get();
+        let challengeBonus = 0;
+        if (challenge?.active) {
+          const newWins = isCorrect ? challenge.wins + 1 : challenge.wins;
+          const newLeft = challenge.roundsLeft - 1;
+          if (newLeft <= 0) {
+            // Challenge complete
+            challengeBonus = newWins === 5 ? score * 2 : 0; // 5/5 perfect = 3x total (1x base + 2x bonus)
+            challenge = null;
+          } else if (!isCorrect) {
+            challenge = null; // Failed
+          } else {
+            challenge = { active: true, roundsLeft: newLeft, wins: newWins };
+          }
+        }
+
         set({
           roundHistory: newHistory,
-          totalScore: get().totalScore + score,
+          totalScore: get().totalScore + score + challengeBonus,
           dailyMissions,
+          challenge,
         });
 
         return result;
@@ -157,6 +179,17 @@ export const useGameStore = create<GameState>()(
 
       setSelectedTitle: (titleId) => set({ selectedTitle: titleId }),
 
+      startChallenge: () => {
+        set({ challenge: { active: true, roundsLeft: 5, wins: 0 } });
+      },
+
+      getTodayRounds: () => {
+        const today = new Date().toDateString();
+        return get().roundHistory.filter(
+          (r) => new Date(r.resolvedAt).toDateString() === today,
+        ).length;
+      },
+
       claimMissionReward: (missionId) => {
         const { dailyMissions } = get();
         if (!dailyMissions) return 0;
@@ -179,6 +212,7 @@ export const useGameStore = create<GameState>()(
         dailyMissions: state.dailyMissions,
         attendance: state.attendance,
         selectedTitle: state.selectedTitle,
+        challenge: state.challenge,
       }),
     }
   )


### PR DESCRIPTION
### **User description**
## Summary

- **챌린지 모드**: 5라운드 연속 적중 시 점수 3배 보너스. 실패 시 챌린지 종료.
- **라운드 카운터**: 오늘 참여한 라운드 수 헤더에 표시

## Test plan

- [ ] 챌린지 시작 버튼 → 진행 배너 표시 확인
- [ ] 5연속 적중 시 3배 보너스 확인
- [ ] 실패 시 챌린지 종료 확인
- [ ] 오늘 라운드 수 카운터 정확도 확인

Closes #27

---
🤖 Generated by Claude Code [claude-sonnet-4-6]


___

### **PR Type**
Enhancement


___

### **Description**
- Implements 5-round challenge mode.

- Adds 3x score bonus for perfect challenge.

- Displays today's total rounds.

- Shows challenge status banner.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  GamePage["Game Page (UI)"] -- "calls actions & displays state" --> GameStore["Game Store (State Management)"]
  GameStore -- "manages challenge state" --> ChallengeLogic["Challenge Mode Logic"]
  GameStore -- "calculates" --> TodayRounds["Today's Rounds Count"]
  ChallengeLogic -- "updates score & challenge status" --> GameStore
  TodayRounds -- "displayed in header" --> GamePage
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Ui changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>page.tsx</strong><dd><code>Integrate Challenge Mode UI and Daily Round Counter Display</code></dd></summary>
<hr>

apps/web/src/app/(game)/page.tsx

<ul><li>Integrated <code>challenge</code>, <code>startChallenge</code>, and <code>getTodayRounds</code> from <br><code>useGameStore</code>.<br> <li> Added a display for "오늘 {getTodayRounds()}R" (Today {rounds}R) in the <br>game header.<br> <li> Implemented conditional UI for the challenge mode, showing a progress <br>banner or a start button.</ul>


</details>


  </td>
  <td><a href="https://github.com/gguloadoong/chimp-pick/pull/28/files#diff-dd20b1a896669dda269ca0a70ed87f5d53e594f7a9449867b156c8d5dbd062b2">+24/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>State management</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gameStore.ts</strong><dd><code>Implement Challenge Mode and Daily Round Counter Logic</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/web/src/stores/gameStore.ts

<ul><li>Added <code>challenge</code> state to manage the challenge mode's active status, <br>rounds left, and wins.<br> <li> Implemented <code>startChallenge</code> action to initialize the challenge state.<br> <li> Modified <code>resolveMyPick</code> to update the <code>challenge</code> state based on round <br>results and apply a 3x score bonus for perfect challenges.<br> <li> Added <code>getTodayRounds</code> function to calculate the number of rounds played <br>today from <code>roundHistory</code>.<br> <li> Ensured the <code>challenge</code> state is persisted across sessions.</ul>


</details>


  </td>
  <td><a href="https://github.com/gguloadoong/chimp-pick/pull/28/files#diff-2eb62ccb2b7914f0e5de71ce1bcf5874844a26febe20d5c40c1cffd567f9d66b">+35/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 도전 모드 추가: 5라운드 동안 연속으로 승리를 얻을 수 있는 새로운 게임 모드
  * 도전 모드 완료 시 점수 2배 보너스 획득
  * 오늘의 라운드 수 배지 표시
  * 진행 중인 도전 모드의 승리 수와 남은 라운드 시각화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->