### PR TITLE
fix: UI 정리 — 부가 정보 접이식, 핵심 영역 집중

### DIFF
--- a/apps/web/src/app/(game)/page.tsx
+++ b/apps/web/src/app/(game)/page.tsx
@@ -61,6 +61,7 @@ export default function GamePage() {
   } = useSettingsStore();
 
   const [showSettings, setShowSettings] = useState(false);
+  const [showExtras, setShowExtras] = useState(false);
   const addToast = useToastStore((s) => s.addToast);
 
   // Ensure daily missions exist
@@ -547,6 +548,15 @@ export default function GamePage() {
           </div>
         )}
 
+        {/* Extras toggle */}
+        <button
+          onClick={() => setShowExtras(!showExtras)}
+          className="w-full py-2 rounded-2xl border border-card-border bg-white text-text-secondary text-xs font-sans font-semibold transition-all hover:border-banana/40"
+        >
+          {showExtras ? "접기 ▲" : `미션 · 기록 · 시즌 ▼${stats.currentStreak >= 2 ? ` · 🔥${stats.currentStreak}연승` : ""}`}
+        </button>
+
+        {showExtras && <>
         {/* Recent results */}
         {recentResults.length > 0 && (
           <div className="bg-white rounded-3xl p-4 border-2 border-card-border clay">
@@ -668,6 +678,7 @@ export default function GamePage() {
             </p>
           </div>
         )}
+        </>}
 
         {/* Footer info */}
         <p className="text-center text-xs text-text-secondary font-sans">


### PR DESCRIPTION
## Summary
- 미션/시즌/스트릭/최근결과를 접이식 서랍으로 이동
- 핵심 영역(질문+버튼) 스크롤 없이 노출

Closes #37

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **게임 페이지에 추가 정보 토글 기능 추가** - 최근 결과, 스트릭 배너, 일일 미션, 시즌 정보, 내일의 보너스를 표시하거나 숨길 수 있는 토글 버튼이 추가되었습니다. 토글 버튼은 숨겨진 상태에서 현재 스트릭을 표시하고, 정보 확장 시 축소 옵션을 보여줍니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->