### PR TITLE
design: 원숭이 몰림 비주얼, 감정 증폭 디자인

### DIFF
--- a/apps/web/src/app/(game)/page.tsx
+++ b/apps/web/src/app/(game)/page.tsx
@@ -12,6 +12,7 @@ import { useCountdown } from "@/hooks/useCountdown";
 import { AVATAR_LEVELS } from "@/types";
 import type { RoundResult } from "@/types";
 import MiniChart from "@/components/game/MiniChart";
+import CrowdGauge from "@/components/game/CrowdGauge";
 import ResultOverlay from "@/components/game/ResultOverlay";
 import ShareCard from "@/components/game/ShareCard";
 import Onboarding from "@/components/game/Onboarding";
@@ -432,41 +433,9 @@ export default function GamePage() {
           </div>
         )}
 
-        {/* Ratio gauge */}
+        {/* Crowd gauge — monkeys rushing! */}
         {currentRound && (currentRound.phase === "OPEN" || currentRound.phase === "CLOSED") && (
-          <div className="bg-white rounded-3xl p-4 border-2 border-card-border clay" data-testid="ratio-gauge">
-            <div className="flex items-center justify-between mb-2">
-              <div className="flex items-center gap-1">
-                <Users size={12} className="text-text-secondary" />
-                <span className="text-xs text-text-secondary font-sans font-semibold">참여 비율</span>
-              </div>
-              <span className="text-xs text-banana font-sans font-semibold">
-                소수파 보너스 적용!
-              </span>
-            </div>
-            {/* Gauge bar */}
-            <div className="flex rounded-2xl overflow-hidden h-10 border-2 border-card-border">
-              <div
-                className="bg-up/20 flex items-center justify-center transition-all duration-500"
-                style={{ width: `${upPct}%` }}
-              >
-                <span className="text-up font-bold text-sm font-sans">
-                  UP {upPct}%
-                </span>
-              </div>
-              <div
-                className="bg-down/20 flex items-center justify-center transition-all duration-500"
-                style={{ width: `${downPct}%` }}
-              >
-                <span className="text-down font-bold text-sm font-sans">
-                  DOWN {downPct}%
-                </span>
-              </div>
-            </div>
-            <p className="text-xs text-text-secondary text-center mt-2 font-sans">
-              적은 쪽을 맞추면 더 높은 점수!
-            </p>
-          </div>
+          <CrowdGauge upPct={upPct} picked={myPick?.direction ?? null} />
         )}
 
         {/* Pick buttons */}

--- a/apps/web/src/components/game/CrowdGauge.tsx
+++ b/apps/web/src/components/game/CrowdGauge.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+/**
+ * CrowdGauge — 원숭이 군중이 UP/DOWN으로 우르르 몰리는 비주얼
+ * 비율에 따라 원숭이 실루엣이 좌우로 분포
+ */
+
+interface CrowdGaugeProps {
+  upPct: number;
+  picked?: "UP" | "DOWN" | null;
+}
+
+const MONKEY_COUNT = 12;
+
+function MonkeySilhouette({ flip, delay, size }: { flip: boolean; delay: number; size: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className="transition-all duration-500"
+      style={{
+        transform: flip ? "scaleX(-1)" : undefined,
+        animationDelay: `${delay}s`,
+      }}
+    >
+      {/* Simple chimp silhouette */}
+      <circle cx={12} cy={8} r={5} />
+      <circle cx={6} cy={6} r={2.5} />
+      <circle cx={18} cy={6} r={2.5} />
+      <ellipse cx={12} cy={17} rx={4} ry={6} />
+      <rect x={7} y={14} width={3} height={6} rx={1.5} />
+      <rect x={14} y={14} width={3} height={6} rx={1.5} />
+    </svg>
+  );
+}
+
+export default function CrowdGauge({ upPct, picked }: CrowdGaugeProps) {
+  const downPct = 100 - upPct;
+  const upCount = Math.round((upPct / 100) * MONKEY_COUNT);
+  const downCount = MONKEY_COUNT - upCount;
+  const upIsMinority = upPct < 50;
+  const downIsMinority = downPct < 50;
+
+  return (
+    <div className="bg-white rounded-3xl p-4 border-2 border-card-border clay" data-testid="crowd-gauge">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-xs font-semibold text-text-secondary font-sans">참여 현황</span>
+        {(upIsMinority || downIsMinority) && (
+          <span className="text-xs font-bold text-banana font-sans animate-pulse">
+            {upIsMinority ? "⬆️ UP 소수파 보너스!" : "⬇️ DOWN 소수파 보너스!"}
+          </span>
+        )}
+      </div>
+
+      {/* Crowd visualization */}
+      <div className="relative flex h-16 rounded-2xl overflow-hidden border-2 border-card-border bg-bg-primary">
+        {/* UP side */}
+        <div
+          className={[
+            "flex items-end justify-center gap-0.5 px-1 transition-all duration-700 relative",
+            picked === "UP" ? "bg-up/15" : "bg-up/5",
+          ].join(" ")}
+          style={{ width: `${upPct}%` }}
+        >
+          <div className="flex items-end justify-center flex-wrap gap-0.5 text-up pb-1">
+            {Array.from({ length: upCount }, (_, i) => (
+              <div
+                key={`up-${i}`}
+                className="animate-bounce"
+                style={{ animationDelay: `${i * 0.12}s`, animationDuration: `${0.8 + (i % 4) * 0.1}s` }}
+              >
+                <MonkeySilhouette flip={false} delay={i * 0.1} size={upCount > 8 ? 14 : 18} />
+              </div>
+            ))}
+          </div>
+          <span className="absolute bottom-0.5 left-1 text-xs font-bold text-up font-sans">
+            UP {upPct}%
+          </span>
+        </div>
+
+        {/* Divider */}
+        <div className="w-0.5 bg-card-border z-10" />
+
+        {/* DOWN side */}
+        <div
+          className={[
+            "flex items-end justify-center gap-0.5 px-1 transition-all duration-700 relative",
+            picked === "DOWN" ? "bg-down/15" : "bg-down/5",
+          ].join(" ")}
+          style={{ width: `${downPct}%` }}
+        >
+          <div className="flex items-end justify-center flex-wrap gap-0.5 text-down pb-1">
+            {Array.from({ length: downCount }, (_, i) => (
+              <div
+                key={`down-${i}`}
+                className="animate-bounce"
+                style={{ animationDelay: `${i * 0.15}s`, animationDuration: `${0.9 + (i % 3) * 0.1}s` }}
+              >
+                <MonkeySilhouette flip={true} delay={i * 0.1} size={downCount > 8 ? 14 : 18} />
+              </div>
+            ))}
+          </div>
+          <span className="absolute bottom-0.5 right-1 text-xs font-bold text-down font-sans">
+            DOWN {downPct}%
+          </span>
+        </div>
+      </div>
+
+      <p className="text-xs text-text-secondary text-center mt-2 font-sans">
+        🐵 원숭이가 적은 쪽을 맞추면 더 높은 점수!
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/game/ResultOverlay.tsx
+++ b/apps/web/src/components/game/ResultOverlay.tsx
@@ -190,24 +190,32 @@ export default function ResultOverlay({
             />
           </div>
 
-          {/* Title */}
+          {/* Title — emotionally amplified */}
           <h2
             className={[
-              "text-3xl font-heading font-bold mb-1",
+              isWin ? "text-4xl" : "text-3xl",
+              "font-heading font-bold mb-1",
               isWin ? "text-up" : "text-down",
             ].join(" ")}
           >
-            {isWin ? "적중!" : "빗나감..."}
+            {isWin
+              ? result.score >= 200 ? "대박!! 🎉🎉" : result.score >= 100 ? "적중! 🎉" : "맞았다! ✨"
+              : "으악... 😵"}
           </h2>
 
-          <p className="text-text-secondary text-sm mb-5 font-sans">
+          <p className={[
+            "text-sm mb-5 font-sans",
+            isWin ? "text-up font-bold" : "text-text-secondary",
+          ].join(" ")}>
             {isWin
-              ? "침팬지의 예감이 적중했다! 가즈아! 🚀"
+              ? result.score >= 200
+                ? "소수파 역배 성공! 침팬지 천재! 🧠🚀"
+                : "침팬지의 예감이 적중했다! 가즈아! 🚀"
               : result.upRatio > 60
-                ? "💡 다음엔 소수파를 노려보세요! 적은 쪽이 더 높은 점수!"
+                ? "💡 소수파를 노려보세요! 적은 쪽이 더 높은 점수!"
                 : result.upRatio < 40
-                  ? "💡 다수파가 항상 옳진 않아요. 직감을 믿어보세요!"
-                  : "🔥 아깝다! 다음 라운드에서 복수하세요!"}
+                  ? "💡 직감을 믿어보세요! 다수파가 항상 옳진 않아요!"
+                  : "🍌 바나나 껍질에 미끄러졌다... 다시 도전!"}
           </p>
 
           {/* Price comparison */}


### PR DESCRIPTION
## Summary

- **CrowdGauge**: 참여비율을 원숭이 군중 몰림으로 시각화 (바운스 애니메이션, 소수파 보너스 강조)
- **감정 증폭**: 고득점 "대박!!" / 일반 "적중!" / 패배 "으악..." 차등 감정
- **전략 힌트**: 패배 시 비율 기반 맞춤 조언

## Test plan

- [ ] 참여비율 원숭이 실루엣 좌우 분포 확인
- [ ] 소수파 쪽 "보너스!" 강조 확인
- [ ] 고득점(200+) 시 "대박!!" 표시 확인
- [ ] 패배 시 전략 힌트 표시 확인

Closes #39

---
🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 참여 현황을 애니메이션 효과와 함께 시각적으로 표시하는 새로운 그래프 컴포넌트가 추가되었습니다.

* **Improvements**
  * 게임 결과 메시지가 획득 점수에 따라 차등으로 표시되도록 개선되었으며, 더 다양한 피드백 메시지가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->