### PR TITLE
feat: Sprint 2 FE — AdSlot + ShareCard + Onboarding

### DIFF
--- a/apps/web/src/components/game/Onboarding.tsx
+++ b/apps/web/src/components/game/Onboarding.tsx
@@ -17,7 +17,7 @@ const STEPS = [
   },
   {
     mood: "up" as const,
-    title: "30초마다 새 라운드!",
+    title: "매 라운드마다 새 문제!",
     description: "시스템이 랜덤 종목을 출제해요. UP 또는 DOWN을 선택하세요!",
     emoji: "⏱️",
   },

--- a/apps/web/src/components/game/ResultOverlay.tsx
+++ b/apps/web/src/components/game/ResultOverlay.tsx
@@ -5,6 +5,7 @@ import type { RoundResult } from "@/types";
 import { formatPrice } from "@/lib/format";
 import Button from "@/components/ui/Button";
 import ChimpCharacter from "@/components/character/ChimpCharacter";
+import AdSlot from "@/components/ui/AdSlot";
 
 const CONFETTI_ITEMS = ["🍌", "🎉", "⭐", "🎊", "✨", "💫", "🏆", "🎈"];
 
@@ -404,6 +405,11 @@ export default function ResultOverlay({
             >
               {isWin ? `+${countScore}점 🏆` : "0점"}
             </div>
+
+            {/* Ad slot (패배 시만 노출) */}
+            {!isWin && (
+              <AdSlot placement="result-lose" className="mb-4" />
+            )}
 
             {/* Actions */}
             <div className="flex gap-2">

--- a/apps/web/src/components/game/ShareCard.tsx
+++ b/apps/web/src/components/game/ShareCard.tsx
@@ -13,26 +13,56 @@ interface ShareCardProps {
 }
 
 export default function ShareCard({ result, totalScore, level, onClose }: ShareCardProps) {
-  const copyText = useCallback(async () => {
-    const text = [
-      "🦍 침팬지픽 결과!",
-      result.isCorrect ? `✅ 적중! +${result.score}점` : "❌ 빗나감...",
-      `종목: ${result.symbolName || "재미 예측"}`,
-      `UP ${result.upRatio}% vs DOWN ${100 - result.upRatio}%`,
-      `총 점수: ${totalScore.toLocaleString()}`,
-      "",
-      "chimp-pick.vercel.app",
-    ].join("\n");
+  const shareText = [
+    `🦍 침팬지픽 ${result.isCorrect ? "적중!" : "도전!"}`,
+    result.isCorrect ? `+${result.score}점 획득 🏆` : "다음엔 맞출 거야 💪",
+    `종목: ${result.symbolName || "재미 예측"}  UP ${result.upRatio}% vs DOWN ${100 - result.upRatio}%`,
+    "나도 예측하러 가기 → chimp-pick.vercel.app",
+  ].join("\n");
 
+  const copyText = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(text);
+      await navigator.clipboard.writeText(shareText);
     } catch {
       // clipboard not available
     }
-  }, [result, totalScore]);
+  }, [shareText]);
+
+  const shareKakao = useCallback(async () => {
+    if (typeof navigator !== "undefined" && navigator.share) {
+      try {
+        await navigator.share({
+          title: "침팬지픽",
+          text: shareText,
+          url: "https://chimp-pick.vercel.app",
+        });
+        return;
+      } catch {
+        // user cancelled or share failed — fall through to link copy
+      }
+    }
+    // fallback: copy link
+    try {
+      await navigator.clipboard.writeText("https://chimp-pick.vercel.app");
+    } catch {
+      // clipboard not available
+    }
+  }, [shareText]);
+
+  const shareTwitter = useCallback(() => {
+    const encoded = encodeURIComponent(shareText);
+    window.open(
+      `https://twitter.com/intent/tweet?text=${encoded}`,
+      "_blank",
+      "noopener,noreferrer",
+    );
+  }, [shareText]);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm" onClick={onClose}>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+      onClick={onClose}
+    >
       <div className="mx-4 w-full max-w-sm" onClick={(e) => e.stopPropagation()}>
         {/* Preview card */}
         <div
@@ -62,15 +92,40 @@ export default function ShareCard({ result, totalScore, level, onClose }: ShareC
           <p className="text-xs text-card-border font-sans mt-3">chimp-pick.vercel.app</p>
         </div>
 
-        {/* Action buttons */}
-        <div className="flex gap-2">
-          <Button variant="primary" size="md" className="flex-1 btn-press" onClick={copyText}>
-            📋 텍스트 복사
+        {/* Share buttons */}
+        <div className="flex gap-2 mb-2">
+          <Button
+            variant="primary"
+            size="md"
+            className="flex-1 btn-press"
+            onClick={shareKakao}
+            aria-label="카카오톡으로 공유"
+          >
+            카카오
           </Button>
-          <Button variant="outline" size="md" className="flex-1 btn-press" onClick={onClose}>
-            닫기
+          <Button
+            variant="outline"
+            size="md"
+            className="flex-1 btn-press"
+            onClick={shareTwitter}
+            aria-label="트위터로 공유"
+          >
+            트위터
+          </Button>
+          <Button
+            variant="outline"
+            size="md"
+            className="flex-1 btn-press"
+            onClick={copyText}
+            aria-label="링크 복사"
+          >
+            링크복사
           </Button>
         </div>
+
+        <Button variant="outline" size="md" className="w-full btn-press" onClick={onClose}>
+          닫기
+        </Button>
       </div>
     </div>
   );

--- a/apps/web/src/components/ui/AdSlot.tsx
+++ b/apps/web/src/components/ui/AdSlot.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+interface AdSlotProps {
+  placement: "result-lose" | "result-win" | "home-bottom" | "between-rounds";
+  className?: string;
+}
+
+export default function AdSlot({ placement, className }: AdSlotProps) {
+  if (placement === "result-win" || placement === "between-rounds") {
+    return null;
+  }
+
+  if (placement === "result-lose") {
+    return (
+      <div
+        data-ad-placement={placement}
+        className={[
+          "h-20 flex items-center justify-between gap-3 px-4",
+          "border-2 border-dashed border-[var(--brand-primary)] rounded-[var(--radius-md)]",
+          "bg-[var(--brand-primary)]/5",
+          className ?? "",
+        ].join(" ")}
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-2xl shrink-0" aria-hidden="true">
+            🍌
+          </span>
+          <div className="min-w-0">
+            <p className="text-xs font-heading font-bold text-[var(--brand-primary)] leading-tight truncate">
+              광고 보고 코인 받기
+            </p>
+            <p className="text-[10px] text-[var(--fg-secondary)] font-sans truncate">
+              광고 영역 (준비 중)
+            </p>
+          </div>
+        </div>
+        <button
+          type="button"
+          disabled
+          aria-label="광고 보고 바나나코인 받기 (준비 중)"
+          className={[
+            "shrink-0 px-3 py-1.5 rounded-[var(--radius-sm)]",
+            "text-xs font-heading font-bold text-white",
+            "bg-[var(--brand-primary)] opacity-50 cursor-not-allowed",
+          ].join(" ")}
+        >
+          받기
+        </button>
+      </div>
+    );
+  }
+
+  // home-bottom: slim banner
+  return (
+    <div
+      data-ad-placement={placement}
+      className={[
+        "h-16 flex items-center justify-center gap-2 px-4",
+        "border-2 border-dashed border-[var(--brand-primary)] rounded-[var(--radius-md)]",
+        "bg-[var(--brand-primary)]/5",
+        className ?? "",
+      ].join(" ")}
+    >
+      <span className="text-xl" aria-hidden="true">
+        🍌
+      </span>
+      <p className="text-[11px] text-[var(--fg-secondary)] font-sans">
+        광고 영역 (준비 중)
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경 사항

Sprint 2 P0 FE 항목 4종 구현.

### 1. AdSlot 컴포넌트 신규 생성
- 파일: `apps/web/src/components/ui/AdSlot.tsx`
- `result-lose` 플레이스홀더: h-20 가로 배너, 바나나 색상 점선 테두리, "광고 보고 코인 받기" CTA
- `home-bottom` 플레이스홀더: h-16 슬림 배너
- `result-win` / `between-rounds`: null 반환 (렌더 없음)
- `data-ad-placement` 속성으로 AdMob SDK 추후 연동 포인트 확보
- 실제 광고 SDK 미연동 — placeholder UI only

### 2. ShareCard SNS 공유 버튼 추가
- 파일: `apps/web/src/components/game/ShareCard.tsx`
- 카카오 공유: `navigator.share()` Web Share API, fallback 링크 복사
- 트위터 공유: `twitter.com/intent/tweet` 직접 열기
- 링크복사: 기존 클립보드 복사 재활용
- 버튼 3종 가로 배열 + 닫기 버튼 분리
- 공유 텍스트 포맷 result 기반으로 통일

### 3. ResultOverlay AdSlot 통합
- 파일: `apps/web/src/components/game/ResultOverlay.tsx`
- 패배(`!isWin`) 시 결과 카드 하단, Actions 버튼 위에 `<AdSlot placement="result-lose" className="mb-4" />` 삽입

### 4. Onboarding 텍스트 업데이트
- 파일: `apps/web/src/components/game/Onboarding.tsx`
- Step 2 타이틀: "30초마다 새 라운드!" → "매 라운드마다 새 문제!" (DEC-007 타임프레임 변경 반영)

## 방향성 확인

침팬지픽 핵심 루프(예측 → 결과 → 보상/랭킹)와 밈 감성 톤앤매너에 부합. SNS 공유는 바이럴 성장 채널, 광고 슬롯은 수익화 기반 마련.

Closes #84

---
🤖 Generated by Claude Code [claude-sonnet-4-6]